### PR TITLE
refactor: 통계 서비스 리팩토링

### DIFF
--- a/src/main/java/com/doittogether/platform/business/housework/HouseworkService.java
+++ b/src/main/java/com/doittogether/platform/business/housework/HouseworkService.java
@@ -1,5 +1,6 @@
 package com.doittogether.platform.business.housework;
 
+import com.doittogether.platform.domain.entity.Housework;
 import com.doittogether.platform.domain.entity.User;
 import com.doittogether.platform.presentation.dto.housework.HouseworkRequest;
 import com.doittogether.platform.presentation.dto.housework.HouseworkResponse;
@@ -8,6 +9,7 @@ import com.doittogether.platform.presentation.dto.housework.IncompleteScoreRespo
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 
 public interface HouseworkService {
@@ -33,5 +35,7 @@ public interface HouseworkService {
 
     Map<String, Integer> calculateHouseworkStatisticsForWeek(Long channelId, LocalDate targetDate);
 
-    IncompleteScoreResponse incompleteScoreResponse(User loginuser, Long channelId, LocalDate targetDate);
+    List<Housework> monthlyHouseworkCheck(Long channelId, LocalDate targetDate);
+
+    IncompleteScoreResponse houseworkIncompleteCountCheck(User loginuser, Long channelId, LocalDate targetDate);
 }

--- a/src/main/java/com/doittogether/platform/business/housework/HouseworkServiceImpl.java
+++ b/src/main/java/com/doittogether/platform/business/housework/HouseworkServiceImpl.java
@@ -155,6 +155,16 @@ public class HouseworkServiceImpl implements HouseworkService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public List<Housework> monthlyHouseworkCheck(Long channelId, LocalDate targetDate){
+
+        final LocalDate firstDayOfMonth = targetDate.with(TemporalAdjusters.firstDayOfMonth()); // 1일
+        final LocalDate lastDayOfMonth = targetDate.with(TemporalAdjusters.lastDayOfMonth()); // 해당 달의 마지막 날
+
+        return houseworkRepository.findByChannelChannelIdAndStartDateBetween(channelId, firstDayOfMonth, lastDayOfMonth);
+    }
+
+    @Override
     public void deleteHousework(final User loginUser, final Long houseworkId, final Long channelId) {
         channelValidator.validateExistChannel(channelId);
         houseworkValidator.validateExistHousework(houseworkId);
@@ -168,7 +178,7 @@ public class HouseworkServiceImpl implements HouseworkService {
     }
 
     @Override
-    public IncompleteScoreResponse incompleteScoreResponse(User loginUser, Long channelId, LocalDate targetDate){
+    public IncompleteScoreResponse houseworkIncompleteCountCheck(User loginUser, Long channelId, LocalDate targetDate){
         channelValidator.validateExistChannel(channelId);
         channelValidator.checkChannelParticipation(loginUser, channelId);
 

--- a/src/main/java/com/doittogether/platform/business/reaction/ReactionServiceImpl.java
+++ b/src/main/java/com/doittogether/platform/business/reaction/ReactionServiceImpl.java
@@ -14,16 +14,17 @@ import com.doittogether.platform.presentation.dto.reaction.ReactionRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class ReactionServiceImpl implements ReactionService {
 
@@ -55,6 +56,7 @@ public class ReactionServiceImpl implements ReactionService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Map<String, Integer> calculateReactionStatisticsForWeek(Long channelId, LocalDate targetDate) {
         LocalDate startOfWeek = targetDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY)); // 일 부터
         LocalDate endOfWeek = targetDate.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY)); // 토 까지
@@ -72,6 +74,7 @@ public class ReactionServiceImpl implements ReactionService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Map<String, Object> calculateReactionsStatisticsMVPForMonthly(Long channelId, LocalDate targetDate) {
         Map<String, Object> statistics = new HashMap<>();
         LocalDate startDate = targetDate.withDayOfMonth(1);

--- a/src/main/java/com/doittogether/platform/business/stastics/StatisticsServiceImpl.java
+++ b/src/main/java/com/doittogether/platform/business/stastics/StatisticsServiceImpl.java
@@ -11,26 +11,26 @@ import com.doittogether.platform.domain.entity.Housework;
 import com.doittogether.platform.domain.entity.User;
 import com.doittogether.platform.domain.enumeration.CompletionStatus;
 import com.doittogether.platform.domain.enumeration.Status;
-import com.doittogether.platform.infrastructure.persistence.housework.HouseworkRepository;
 import com.doittogether.platform.infrastructure.persistence.user.UserRepository;
 import com.doittogether.platform.presentation.dto.stastics.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.temporal.TemporalAdjusters;
-import java.util.*;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class StatisticsServiceImpl implements StatisticsService {
 
-    private final HouseworkRepository houseworkRepository;
     private final UserRepository userRepository;
     private final ChannelValidator channelValidator;
-
     private final HouseworkService houseworkService;
     private final ReactionService reactionService;
 
@@ -40,12 +40,11 @@ public class StatisticsServiceImpl implements StatisticsService {
         channelValidator.validateExistChannel(channelId);
         channelValidator.checkChannelParticipation(loginUser, channelId);
 
-        final LocalDate startOfWeek = targetDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
-        final LocalDate endOfWeek = targetDate.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY));
+        final List<Housework> houseworkList = houseworkService.monthlyHouseworkCheck(channelId, targetDate);
 
-        final List<Housework> houseworkList = houseworkRepository.findByChannelChannelIdAndStartDateBetween(channelId, startOfWeek, endOfWeek);
         try {
             final List<PersonalCompleteScoreResponse> statisticsList = generateWeeklyStatistics(houseworkList);
+
             return CompleteScoreResponse.of(statisticsList);
         } catch (IllegalArgumentException e) {
             throw new StatisticsException(ExceptionCode.HOUSEWORK_NOT_NULL);
@@ -76,12 +75,10 @@ public class StatisticsServiceImpl implements StatisticsService {
         channelValidator.validateExistChannel(channelId);
         channelValidator.checkChannelParticipation(loginUser, channelId);
 
-        LocalDate firstDayOfMonth = targetDate.with(TemporalAdjusters.firstDayOfMonth());
-        LocalDate lastDayOfMonth = targetDate.with(TemporalAdjusters.lastDayOfMonth());
-
-        List<Housework> houseworkList = houseworkRepository.findByChannelChannelIdAndStartDateBetween(channelId, firstDayOfMonth, lastDayOfMonth);
+        final List<Housework> houseworkList = houseworkService.monthlyHouseworkCheck(channelId, targetDate);
         try {
             List<SingleDayStatisticsResponse> statisticsList = generateMonthlyStatistics(houseworkList);
+
             return MonthlyStatisticsResponse.of(statisticsList);
         } catch (IllegalArgumentException e) {
             throw new StatisticsException(ExceptionCode.HOUSEWORK_NOT_NULL);
@@ -97,78 +94,57 @@ public class StatisticsServiceImpl implements StatisticsService {
         return MonthlyMVPResponse.of(reactionStatistics);
     }
 
-    // 아래 메서드들 Util로 빼야 하는가?
     public List<PersonalCompleteScoreResponse> generateWeeklyStatistics(List<Housework> houseworkList) {
+        return houseworkList.stream()
+                .collect(Collectors.groupingBy(Housework::retrieveAssignee)) // Assignee별 그룹화
+                .entrySet().stream()
+                .map(entry -> {
+                    Assignee assignee = entry.getKey();
+                    List<Housework> dailyHouseworks = entry.getValue();
 
-        // 담당자 별로 집안일을 그룹화
-        Map<Assignee, List<Housework>> groupedByNickName = houseworkList.stream()
-                .collect(Collectors.groupingBy(Housework::retrieveAssignee));
+                    String nickName = assignee.retrieveUser().retrieveNickName();
+                    long completedTasks = dailyHouseworks.stream()
+                            .filter(housework -> housework.retrieveStatus() == Status.COMPLETE)
+                            .count();
+                    String profileImageUrl = userRepository.findProfileImageUrlByNickName(nickName).orElse("");
 
-        //그룹회된 담당자 별로 통계 계산
-        List<PersonalCompleteScoreResponse> statisticsList = new ArrayList<>();
-
-        for (Map.Entry<Assignee, List<Housework>> entry : groupedByNickName.entrySet()) {
-            Assignee assignee = entry.getKey();
-            List<Housework> dailyHouseworks = entry.getValue();
-
-            // Response 필드 정보 조회
-            String nickName = assignee.retrieveUser().retrieveNickName();
-            long completedTasks = dailyHouseworks.stream()
-                    .filter(housework -> housework.retrieveStatus() == Status.COMPLETE)
-                    .count();
-            String url = userRepository.findProfileImageUrlByNickName(nickName).orElse("");
-
-            // 사용자 별 응답 객체 생성
-            statisticsList.add(new PersonalCompleteScoreResponse(nickName, Math.toIntExact(completedTasks), url));
-        }
-
-        // 집안일 완료 개수 내림차 순으로 정렬
-        statisticsList.sort(Comparator.comparing(PersonalCompleteScoreResponse::completeCount).reversed());
-
-        return statisticsList;
+                    return new PersonalCompleteScoreResponse(nickName, Math.toIntExact(completedTasks), profileImageUrl);
+                })
+                .sorted(Comparator.comparing(PersonalCompleteScoreResponse::completeCount).reversed()) // 완료 개수 내림차순 정렬
+                .toList();
     }
 
     public List<SingleDayStatisticsResponse> generateMonthlyStatistics(List<Housework> houseworkList) {
-        // 날짜별로 집안일을 그룹화
-        Map<LocalDate, List<Housework>> groupedByDate = houseworkList.stream()
-                .collect(Collectors.groupingBy(Housework::retrieveStartDate));
+        return houseworkList.stream()
+                .collect(Collectors.groupingBy(Housework::retrieveStartDate)) // 날짜별 그룹화
+                .entrySet().stream()
+                .map(entry -> {
+                    LocalDate date = entry.getKey();
+                    List<Housework> dailyHouseworks = entry.getValue();
 
-        // 그룹화된 날짜별로 통계 계산
-        List<SingleDayStatisticsResponse> statisticsList = new ArrayList<>();
+                    int totalTasks = dailyHouseworks.size();
+                    long completedTasks = dailyHouseworks.stream()
+                            .filter(housework -> housework.retrieveStatus() == Status.COMPLETE)
+                            .count();
+                    CompletionStatus status = calculateCompletionStatus(dailyHouseworks, totalTasks);
 
-        for (Map.Entry<LocalDate, List<Housework>> entry : groupedByDate.entrySet()) {
-            LocalDate date = entry.getKey();
-            List<Housework> dailyHouseworks = entry.getValue();
-
-            // 전체 집안일 개수
-            int totalTasks = dailyHouseworks.size();
-
-            // 완료된 집안일 개수
-            long completedTasks = dailyHouseworks.stream()
-                    .filter(housework -> housework.retrieveStatus() == Status.COMPLETE)
-                    .count();
-
-            // 완료 상태 (3가지 중 하나: ALL_DONE, INCOMPLETE_REMAINING, NO_HOUSEWORK)
-            CompletionStatus status = calculateCompletionStatus(dailyHouseworks, totalTasks);
-
-            // 결과 리스트에 추가
-            statisticsList.add(new SingleDayStatisticsResponse(date, totalTasks, (int) completedTasks, status));
-        }
-
-        // 날짜 기준으로 오름차순 정렬
-        statisticsList.sort(Comparator.comparing(SingleDayStatisticsResponse::retrieveDate));
-        return statisticsList;
+                    return new SingleDayStatisticsResponse(date, totalTasks, Math.toIntExact(completedTasks), status);
+                })
+                .sorted(Comparator.comparing(SingleDayStatisticsResponse::retrieveDate)) // 날짜 기준 오름차순 정렬
+                .toList();
     }
 
     private CompletionStatus calculateCompletionStatus(List<Housework> houseworks, int totalTasks) {
         if (totalTasks == 0) {
             return CompletionStatus.NO_HOUSEWORK;
         }
-        boolean allComplete = houseworks.stream().allMatch(h -> h.retrieveStatus() == Status.COMPLETE);
-        if (allComplete) {
+
+        if (houseworks.stream().allMatch(h -> h.retrieveStatus() == Status.COMPLETE)) {
             return CompletionStatus.ALL_DONE;
-        } else {
-            return CompletionStatus.INCOMPLETE_REMAINING;
         }
+
+        return CompletionStatus.INCOMPLETE_REMAINING;
     }
+
+
 }

--- a/src/main/java/com/doittogether/platform/presentation/controller/housework/HouseworkControllerImpl.java
+++ b/src/main/java/com/doittogether/platform/presentation/controller/housework/HouseworkControllerImpl.java
@@ -212,7 +212,7 @@ public class HouseworkControllerImpl implements
         return ResponseEntity.status(HttpStatus.OK).body(
                 SuccessResponse.onSuccess(
                         SuccessCode._OK,
-                        houseworkService.incompleteScoreResponse(loginUser, channelId, targetDate)
+                        houseworkService.houseworkIncompleteCountCheck(loginUser, channelId, targetDate)
                 ));
     }
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

> #### 🔗 관련 이슈
> 
> <!-- 관련 이슈가 어떤건지 작성해주세요 -->
> 
> close #4 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
통계 도메인의 리팩토링을 진행하였습니다.
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
[변경 사항]
1. StatisticsServiceImpl의 월 별 집안일 조회 부분을 HouseworkServiceImpl에서 조회한 뒤 메서드를 불러오는 방식으로 변경
또한, HouseworkServiceImpl에 구현된 메서드를 불러옴으로써 StatisticsServiceImpl의 코드 중복을 최소화하였습니다.

2. for문 대신 가독성을 올리기 위해 stream을 적용하는 방식으로 일괄 변경하였습니다.

3. 가독성 문제로 else문을 제거했습니다.

4. 통일성을 위해 HouseworkServiceImpl의 incompleteScoreResponse 메서드 명을 houseworkIncompleteCountCheck로 변경했습니다.

5. HouseworkServiceImpl와 ReactionServiceImpl에서 조회 메서드의 경우 @Transactional(readOnly = true)를 적용하여 조회 외의 기능을 차단하여 성능을 상향했습니다.,

## 추후 리팩토링 진행 사항
* N+1 문제 해결 -> 트러블 슈팅으로 정리 후 리팩토링 진행 예정
