### PR TITLE
[CHORE] redis 관련 레파지토리를 사용하지 않기 때문에, JpaRepository 충돌 경고 해결 옵션 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,8 @@ spring:
 
   data:
     redis:
+      repositories:
+        enabled: false
       host: ${REDIS_HOST} # redis 서버의 호스트 이름
       port: ${REDIS_PORT} # redis 서버의 포트 번호
       maxmemory: 128M


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

> #### 🔗 관련 이슈
> 
> <!-- 관련 이슈가 어떤건지 작성해주세요 -->
> 
> close #16 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
Spring data JPA repository 와 Spirng data redis Repository가 모두 인식되어서 Redis 가 Repository 를 인식하지 못하는 이슈로
스프링부트가 실행될 때 불필요한 로그가 계속 출력 되는 이슈 해결

![image](https://github.com/user-attachments/assets/c7c7845f-0145-4459-92ae-38b6ab622896)

redis repository 를 사용하지 않고 redisTemplate 을 통한 구현이 되어 있어서 repositories 의 사용 여부를 false 로 설정하면 된다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
chore : application.yml 에 옵션 추가


## 💻 실행 결과 <!-- 쿼리 동작 캡쳐 화면과 테스트 코드 통과 캡쳐 화면을 넣어주세요 -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
